### PR TITLE
Convert tabs to spaces.

### DIFF
--- a/command_line_tool.py
+++ b/command_line_tool.py
@@ -11,44 +11,44 @@ photo_dir = ""
 output_dir = ""
 
 def apply_mask():
-	for file in os.listdir(photo_dir):
-		if file.endswith('.JPG'):
-			image = cv2.imread(os.path.join(photo_dir, file))
-			masked_image = corn_app.mask.mask_yellow(image)
-			os.chdir(output_dir)
-			cv2.imwrite('mask_' + file, masked_image)
+    for file in os.listdir(photo_dir):
+        if file.endswith('.JPG'):
+            image = cv2.imread(os.path.join(photo_dir, file))
+            masked_image = corn_app.mask.mask_yellow(image)
+            os.chdir(output_dir)
+            cv2.imwrite('mask_' + file, masked_image)
 
 
 def apply_contours():
-	for file in os.listdir(photo_dir):
-		if file.endswith('.JPG'):
-			image = cv2.imread(os.path.join(photo_dir, file))
-			contoured_image = corn_app.contour.find_contours(image)
-			os.chdir(output_dir)
-			cv2.imwrite('contours_' + file, contoured_image)
+    for file in os.listdir(photo_dir):
+        if file.endswith('.JPG'):
+            image = cv2.imread(os.path.join(photo_dir, file))
+            contoured_image = corn_app.contour.find_contours(image)
+            os.chdir(output_dir)
+            cv2.imwrite('contours_' + file, contoured_image)
 
 
 def process():
-	for file in os.listdir(photo_dir):
-		if file.endswith('.JPG'):
-			image = cv2.imread(os.path.join(photo_dir, file))
-			contoured_image = corn_app.contour.find_contours(corn_app.mask.mask_yellow(image))
-			os.chdir(output_dir)
-			cv2.imwrite('processed_' + file, contoured_image)
+    for file in os.listdir(photo_dir):
+        if file.endswith('.JPG'):
+            image = cv2.imread(os.path.join(photo_dir, file))
+            contoured_image = corn_app.contour.find_contours(corn_app.mask.mask_yellow(image))
+            os.chdir(output_dir)
+            cv2.imwrite('processed_' + file, contoured_image)
 
 
 def main(args):
-	if args.mask is True:
-		apply_mask()
-		exit(0)
+    if args.mask is True:
+        apply_mask()
+        exit(0)
 
-	if args.contour is True:
-		apply_contours()
-		exit(0)
+    if args.contour is True:
+        apply_contours()
+        exit(0)
 
-	if args.process is True:
-		process()
-		exit(0)
+    if args.process is True:
+        process()
+        exit(0)
 
 
 parser = argparse.ArgumentParser(description='Applies a mask and contours to pictures of corn.', prog='Corn Kernel Counter Prep Application')
@@ -59,13 +59,13 @@ parser.add_argument('-p', '--process', action='store_true', default=False, help=
 args = parser.parse_args()
 
 try:
-	json_data = json.load(open('config.json'))
+    json_data = json.load(open('config.json'))
 except IOError:
-	print('There was an error opening the \'config.json\' file, or it does not exist. Please create one in a similar structure to \'sample_config.json\'')
-	sys.exit(1)
+    print('There was an error opening the \'config.json\' file, or it does not exist. Please create one in a similar structure to \'sample_config.json\'')
+    sys.exit(1)
 
 photo_dir = json_data['cornPhotoDir']
 output_dir = json_data['contourPhotoDir']
 
 if __name__ == '__main__':
-	main(args)
+    main(args)

--- a/corn_app/mask.py
+++ b/corn_app/mask.py
@@ -1,8 +1,8 @@
 """ Converts all image pixels not in the required HSV range to black
 
 Attributes:
-	LOWER_BOUND (array): HSV values for the lower boundary of color
-	UPPER_BOUND (array): HSV values for the upper boundary of color
+    LOWER_BOUND (array): HSV values for the lower boundary of color
+    UPPER_BOUND (array): HSV values for the upper boundary of color
 """
 import cv2
 import numpy as np
@@ -12,27 +12,27 @@ LOWER_BOUND_YELLOW = [20,100,100]
 UPPER_BOUND_YELLOW = [40,255,255]
 
 def mask_yellow(image):
-	"""Converts all image pixels not in the yellow HSV range to black
+    """Converts all image pixels not in the yellow HSV range to black
 
-	Args:
-		image (openCV Image): An open Image object.
+    Args:
+        image (openCV Image): An open Image object.
 
-	Returns:
-		bgr_yellow_image (openCV Image): An Image with yellow pixels extracted
-	"""
+    Returns:
+        bgr_yellow_image (openCV Image): An Image with yellow pixels extracted
+    """
 
-	if image is None:
-		return None
+    if image is None:
+        return None
 
-	hsv_image = cv2.cvtColor(image, cv2.COLOR_BGR2HSV)
-	blur = cv2.GaussianBlur(hsv_image, (5,5), 0)
+    hsv_image = cv2.cvtColor(image, cv2.COLOR_BGR2HSV)
+    blur = cv2.GaussianBlur(hsv_image, (5,5), 0)
 
-	lower_yellow = np.array(LOWER_BOUND_YELLOW)
-	upper_yellow = np.array(UPPER_BOUND_YELLOW)
+    lower_yellow = np.array(LOWER_BOUND_YELLOW)
+    upper_yellow = np.array(UPPER_BOUND_YELLOW)
 
-	yellow_mask = cv2.inRange(blur, lower_yellow, upper_yellow)
+    yellow_mask = cv2.inRange(blur, lower_yellow, upper_yellow)
 
-	hsv_yellow_image = cv2.bitwise_and(image, image, mask = yellow_mask)
-	bgr_yellow_image = cv2.cvtColor(hsv_yellow_image, cv2.COLOR_HSV2BGR)
+    hsv_yellow_image = cv2.bitwise_and(image, image, mask = yellow_mask)
+    bgr_yellow_image = cv2.cvtColor(hsv_yellow_image, cv2.COLOR_HSV2BGR)
 
-	return bgr_yellow_image
+    return bgr_yellow_image


### PR DESCRIPTION
A tab could be a different number of columns depending on your environment, but a space is always one column. Four spaces per tab seems to be a standard with python, so I suggest we stick with that.